### PR TITLE
Check if the child object exists, but isn't an object

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -85,8 +85,8 @@
             if (i === n - 1) {
                 options.unset ? delete result[field] : result[field] = val;
             } else {
-                //Create the child object if it doesn't exist
-                if (typeof result[field] === 'undefined') {
+                //Create the child object if it doesn't exist, or isn't an object
+                if (typeof result[field] === 'undefined' || ! _.isObject(result[field])) {
                     result[field] = {};
                 }
                 


### PR DESCRIPTION
If I have a model like this:

``` javascript
{
   name : 'test user'
   attributes  : ''
}
```

and I try to do `person.set('attributes', { 'k1' : 'v1', 'k2' : 'v2' })`

It won't work because attributes isn't `undefined` but also isn't an object. I updated it to check if the current object is either undefined or not an object to give the placeholder object container.
