### PR TITLE
JSHint linting

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -1,4 +1,4 @@
-/*jshint expr:true*/
+/*jshint expr:true eqnull:true */
 /**
  *
  * Improves Backbone Model support when nested attributes are used.
@@ -56,7 +56,7 @@
             }
             result = result[fields[i]];
 
-            if (result === null && i < n - 1) {
+            if (result == null && i < n - 1) {
                 result = {};
             }
             
@@ -129,7 +129,7 @@
             var attrs, attr, val;
 
             // Handle both `"key", value` and `{key: value}` -style arguments.
-            if (_.isObject(key) || key === null) {
+            if (_.isObject(key) || key == null) {
                 attrs = key;
                 options = value;
             } else {
@@ -194,7 +194,7 @@
         },
 
         has: function(attr) {
-          return getNested(this.attributes, attr) !== null;
+          return getNested(this.attributes, attr) != null;
         },
 
         change: function(options) {
@@ -241,7 +241,7 @@
           });
 
           if (!arguments.length) return !_.isEmpty(this.changed);
-          return getNested(this.changed, attr) !== null;
+          return getNested(this.changed, attr) != null;
         },
 
         changedAttributes: function(diff) {


### PR DESCRIPTION
Hi, if it was a desire to keep this app ready for lint checks development I set up 2 options.

`expr: true` is for things such as `return_exists || (return_exists === false);`.

`eqnull:true` allows for us to use `(var == null)` which checks for `undefined` and `null` via type coercion (http://javascriptweblog.wordpress.com/2011/02/07/truth-equality-and-javascript/). Had to look that up.

I think we have a valuable module and should keep thing in ship shape.
