### PR TITLE
Add AMD support

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -2,15 +2,15 @@
  * Improves Backbone Model support when nested attributes are used.
  * get() and set() can take paths e.g. 'user.name'
  */
-;(function (factory) {
-    if (typeof define ==='function' && define.amd) {
+;(function(factory) {
+    if (typeof define === 'function' && define.amd) {
         // AMD
         define(['underscore', 'backbone'], factory);
     } else {
         // globals
         factory(_, Backbone);
     }
-}(function (_, Backbone) {
+}(function(_, Backbone) {
     
     /**
      * Takes a nested object and returns a shallow object keyed with the path names


### PR DESCRIPTION
Use the AMD define method if it is available. I needed this change to use Backbone.noConflict() instead of global Backbone within a require.js application and thought it might be useful to others, too.
