### PR TITLE
Allow nested attribute as Model identifier

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -145,7 +145,7 @@
             if (!this._validate(attrs, options)) return false;
 
             // Check for changes of `id`.
-            if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
+            if (!_.isUndefined(getNested(attrs, this.idAttribute))) this.id = getNested(attrs, this.idAttribute);
 
             var changes = options.changes = {};
             var now = this.attributes;


### PR DESCRIPTION
As title suggests.

``` javascript
var awesome = new Backbone.DeepModel({
 idAttribute: 'nested.id'
});
```
