### PR TITLE
Bugfix toJSON

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -278,8 +278,11 @@
           }
 
           return changed;
-        }
+        },
 
+        toJSON: function(){
+          return $.extend(true, {}, this.attributes)
+        }
     });
 
 

--- a/test/deep-model.test.js
+++ b/test/deep-model.test.js
@@ -571,6 +571,15 @@ test('hasChanged(attr): behaves as Model for top level attributes', function() {
     equal(deepModel.hasChanged('test'), model.hasChanged('test'));
 });
 
+test('toJSON(): Return a copy of the model\'s attributes for JSON stringification', function(){
+    var deepModel = new Backbone.DeepModel({
+      foo: {bar: 1}
+    })
+    var json = deepModel.toJSON()
+    deepEqual(json, {foo: {bar: 1}})
+    json.foo.bar = 2
+    deepEqual(deepModel.attributes, {foo: {bar: 1}})
+})
 
 test('hasChanged(attr): with deep attributes', function() {
     var deepModel = new Backbone.DeepModel({


### PR DESCRIPTION
toJSON is a function Return a copy of the model's attributes for JSON stringification. 

In Backbone.Model.toJSON 

```
  toJSON: function(options) {
      return _.clone(this.attributes);
  }
```

The underscore's clone isn't deep clone . 
