### PR TITLE
AMD: Return DeepModel instead of Backbone

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -293,6 +293,6 @@
     //For use in NodeJS
     if (typeof module != 'undefined') module.exports = DeepModel;
     
-    return Backbone;
+    return DeepModel;
 
 }));


### PR DESCRIPTION
When using AMD, DeepModel should be exported/returned instead of Backbone. If consumers need access to the Backbone namespace, then they'll have that listed as a separate dependency.
