### PR TITLE
use of _escapedAttributes affected by upgrade in backbone and underscorejs

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -162,7 +162,7 @@
 
               var currentValue = getNested(now, attr),
                   previousValue = getNested(prev, attr),
-                  escapedValue = getNested(escaped, attr),
+                  //escapedValue = getNested(escaped, attr),
                   hasCurrentValue = _.isUndefined(currentValue),
                   hasPreviousValue = _.isUndefined(previousValue);
 


### PR DESCRIPTION
https://github.com/documentcloud/backbone/issues/1914#issuecomment-11348478

I removed this line that was affected by a recent change.  The details in the comment should be good.
