### PR TITLE
fix for issue 42

### DIFF
--- a/lib/underscore.mixin.deepExtend.js
+++ b/lib/underscore.mixin.deepExtend.js
@@ -26,16 +26,22 @@
   };
 
   isBasicObject = function(object) {
-    return (object.prototype === {}.prototype || object.prototype === Object.prototype) && _.isObject(object) && !_.isArray(object) && !_.isFunction(object) && !_.isDate(object) && !_.isRegExp(object) && !_.isArguments(object);
+    return !!object && (object.prototype === {}.prototype || object.prototype === Object.prototype) && _.isObject(object) && !_.isArray(object) && !_.isFunction(object) && !_.isDate(object) && !_.isRegExp(object) && !_.isArguments(object);
   };
 
   basicObjects = function(object) {
+    if (!isBasicObject(object)) {
+      return [];
+    }
     return _.filter(_.keys(object), function(key) {
       return isBasicObject(object[key]);
     });
   };
 
   arrays = function(object) {
+    if (!isBasicObject(object)) {
+      return [];
+    }
     return _.filter(_.keys(object), function(key) {
       return _.isArray(object[key]);
     });

--- a/test/deep-model.test.js
+++ b/test/deep-model.test.js
@@ -792,3 +792,18 @@ test("defaults: with deep attributes", function() {
     equal(model.get('details.name.last'), 'Smith');
     equal(model.get('details.name.initial'), 'Z');
 });
+
+test("defaults: with empty constructor", function() {
+  DefaultsModel = Backbone.DeepModel.extend({
+    defaults: {
+      firstName: 'john',
+      lastName: 'doe'
+    }
+  });
+
+  var model = new DefaultsModel();
+
+  equal(model.get('firstName'), 'john');
+  equal(model.get('lastName'), 'doe');
+});
+

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,7 @@
     <script src="lib/qunit.js"></script>
 
     <script src="lib/underscore-1.4.3.js"></script>
-    <script src="lib/underscore.mixin.deepExtend.js"></script>
+    <script src="../lib/underscore.mixin.deepExtend.js"></script>
     <script src="lib/backbone-0.9.9.js"></script>
     <script src="../src/deep-model.js"></script>
 </head>


### PR DESCRIPTION
Pushing a fix to allow a model extended from deepModel to be constructed with no passed in attribute object. 

Also disconnecting the test index.html file from the underscore mixin in the test library and attaching it to the one in the base lib directory.
