### PR TITLE
Fix "Uncaught TypeError: Object.keys called on non-object" when no initial attributes

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -135,7 +135,7 @@
             if (defaults = _.result(this, 'defaults')) {
                 //<custom code>
                 // Replaced the call to _.defaults with _.deepExtend.
-                attrs = _.deepExtend({}, defaults, attributes);
+                attrs = _.deepExtend({}, defaults, attrs);
                 //</custom code>
             }
             this.set(attrs, {silent: true});

--- a/test/deep-model.test.js
+++ b/test/deep-model.test.js
@@ -792,3 +792,21 @@ test("defaults: with deep attributes", function() {
     equal(model.get('details.name.last'), 'Smith');
     equal(model.get('details.name.initial'), 'Z');
 });
+
+test("defaults: with no initial attributes", function() {
+    DefaultsModel = Backbone.DeepModel.extend({
+        defaults: {
+            details: {
+                name: {
+                    last: 'Smith',
+                    initial: 'J'
+                }
+            }
+        }
+    });
+
+    var model = new DefaultsModel();
+
+    equal(model.get('details.name.last'), 'Smith');
+    equal(model.get('details.name.initial'), 'J');
+});


### PR DESCRIPTION
I was getting an 

```
Uncaught TypeError: Object.keys called on non-object"
```

for models where I had defaults defined and I was not sending in any initial attributes.

Includes a new test case.
