### PR TITLE
Fix for "set" method with empty options

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -180,6 +180,7 @@
             } else {
               (attrs = {})[key] = val;
             }
+            options = options || {};
 
             // Extract attributes and options.
             var silent = options && options.silent;


### PR DESCRIPTION
When you call `deepmodel.set('key', value)` it fails in backbone validate method, because `_validate` expects defined options object:

``` js
_validate: function(attrs, options) {
    if (!options.validate || !this.validate) return true;
    ...
```
