### PR TITLE
Handle 'null' value in isBasicObject check in _.mixin.deepExtend

### DIFF
--- a/lib/underscore.mixin.deepExtend.js
+++ b/lib/underscore.mixin.deepExtend.js
@@ -26,7 +26,7 @@
   };
 
   isBasicObject = function(object) {
-    return (object.prototype === {}.prototype || object.prototype === Object.prototype) && _.isObject(object) && !_.isArray(object) && !_.isFunction(object) && !_.isDate(object) && !_.isRegExp(object) && !_.isArguments(object);
+    return (object == null || object.prototype === {}.prototype || object.prototype === Object.prototype) && _.isObject(object) && !_.isArray(object) && !_.isFunction(object) && !_.isDate(object) && !_.isRegExp(object) && !_.isArguments(object);
   };
 
   basicObjects = function(object) {


### PR DESCRIPTION
Make sure that properties presently set to null are returned as basic objects.
