### PR TITLE
IE7 bug: Trailing comma in DeepModel definition

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -297,7 +297,7 @@
           //<custom code>
           return _.deepClone(this._previousAttributes);
           //</custom code>
-        },
+        }
     });
 
 


### PR DESCRIPTION
Remove trailing comma after 'previousAttributes' function defintion in DeepModel, which causes bug in IE7
