### PR TITLE
Triggering events on all parent attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Example code:
         console.log(val);
     });
 
+    //... and all parent attributes as well
+    model.bind('change:user.name', function(model, val) { console.log(val); });
+    model.bind('change:user', function(model, val) { console.log(val); });
+
     //Wildcards are supported
     model.bind('change:user.*', function() {});
     

--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -225,6 +225,25 @@
                 }
                 //</custom code>
               }
+              //<custom code>
+              // Flag triggered events so that they are not triggered more then once.
+              var triggered = {};
+              _.each(changes, function(key) {
+                  
+                var fields = key.split(separator);
+
+                //Trigger change events for parent keys without wildcard (*) notation.
+
+                for(var n = fields.length - 1; n > 0; n--) {
+                  var parentKey = _.first(fields, n).join(separator);
+
+                    if (!triggered[parentKey]) {
+                        this.trigger('change:' + parentKey, this, getNested(current, parentKey), options);
+                    }
+                    triggered[parentKey] = true;
+                }
+              }, this);
+              //</custom code>                
             }
 
             if (changing) return this;

--- a/test/deep-model.test.js
+++ b/test/deep-model.test.js
@@ -262,6 +262,8 @@ test("set: Triggers model change:[attribute] events", function() {
             'change:user.name.first',
             'change:user.name.*',
             'change:user.*',
+            'change:user.name',
+            'change:user',
             'change'
         ]);
     })();
@@ -503,6 +505,8 @@ test("unset: Triggers model change:[attribute] events", function() {
             'change:user.name.first',
             'change:user.name.*',
             'change:user.*',
+            'change:user.name',
+            'change:user',
             'change'
         ]);
     })();


### PR DESCRIPTION
Hi, Thanks for the plugin! Great work! I was missing a way of triggering events on parent attributes. This is not exactly the same as wildcards because wildcards can be triggered more then once during one call to .set(). Imagine this example:

`model.on('change:box.*', transform);`
`model.set({ 'box.x':  20, 'box.y': 50 });`

In this example, `transform()` is called twice which is not desirable. I added a facility so that events are triggered an all the parent attributes as well but only once:

`model.on('change:box', transform);`
`model.set({ 'box.x':  20, 'box.y': 50 });`

`transform()` is now called only once.

Hope this might be of use for others as well. Please let me know if I forgot anything or if you feel there is something that should be done differently. Thanks!
