### PR TITLE
Trigger change events only once + Trigger change event for parent keys

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -229,6 +229,13 @@
                     alreadyTriggered[wildcardKey] = true; // * @restorer
                     this.trigger('change:' + wildcardKey, this, getNested(current, parentKey), options);
                   } // * @restorer
+
+                  // + @restorer
+                  if (!alreadyTriggered.hasOwnProperty(parentKey) || !alreadyTriggered[parentKey]) {
+                    alreadyTriggered[parentKey] = true;
+                    this.trigger('change:' + parentKey, this, getNested(current, parentKey), options);
+                  }
+                  // - @restorer
                 }
                 //</custom code>
               }

--- a/test/deep-model.test.js
+++ b/test/deep-model.test.js
@@ -261,7 +261,9 @@ test("set: Triggers model change:[attribute] events", function() {
             'change:id',
             'change:user.name.first',
             'change:user.name.*',
+            'change:user.name', // * @restorer
             'change:user.*',
+            'change:user', // * @restorer
             'change'
         ]);
     })();
@@ -502,7 +504,9 @@ test("unset: Triggers model change:[attribute] events", function() {
             'change',
             'change:user.name.first',
             'change:user.name.*',
+            'change:user.name', // * @restorer
             'change:user.*',
+            'change:user', // * @restorer
             'change'
         ]);
     })();
@@ -795,11 +799,145 @@ test("set: Trigger change events only once", function() {
             'change:id',
             'change:user.name.first',
             'change:user.name.*',
+            'change:user.name',
             'change:user.*',
+            'change:user',
             'change:user.name.last',
             'change'
         ]);
     })();
 });
 
+test('set: Trigger model change:[attribute] event for parent keys (like wildcard)', function() {
+    (function() {
+        var model = create();
+        var triggered = false;
+
+        model.on('change:user', function(model, val) {
+            deepEqual(val, {});
+            triggered = true;
+        });
+
+        model.set('user', {});
+        ok(triggered);
+    })();
+
+    (function() {
+        var model = create();
+        var triggered = false;
+
+        model.on('change:user', function(model, val) {
+            deepEqual(val, null);
+            triggered = true;
+        });
+
+        model.set('user', null);
+        ok(triggered);
+    })();
+
+    (function() {
+        var model = create();
+        var triggered = false;
+
+        model.on('change:user', function(model, val) {
+            ok(typeof(val) === 'undefined');
+            triggered = true;
+        });
+
+        model.set('user', void 0, true);
+        ok(triggered);
+    })();
+
+    (function() {
+        var model = new Backbone.DeepModel({
+            id: 123,
+            user: {}
+        });
+
+        var triggered = false;
+
+        model.on('change:user', function(model, val) {
+            deepEqual(val, {
+                type: 'Spy',
+                name: {
+                    first: 'Sterling',
+                    last: 'Archer'
+                }
+            });
+
+            triggered = true;
+        });
+
+        model.set('user', {
+            type: 'Spy',
+            name: {
+                first: 'Sterling',
+                last: 'Archer'
+            }
+        });
+
+        ok(triggered);
+    })();
+
+    (function() {
+        var model = new Backbone.DeepModel({
+            id: 123,
+            user: null
+        });
+
+        var triggered = false;
+
+        model.on('change:user', function(model, val) {
+            deepEqual(val, {
+                type: 'Spy',
+                name: {
+                    first: 'Sterling',
+                    last: 'Archer'
+                }
+            });
+
+            triggered = true;
+        });
+
+        model.set('user', {
+            type: 'Spy',
+            name: {
+                first: 'Sterling',
+                last: 'Archer'
+            }
+        });
+
+        ok(triggered);
+    })();
+
+    (function() {
+        var model = new Backbone.DeepModel({
+            id: 123
+        });
+
+        var triggered = false;
+
+        model.on('change:user', function(model, val) {
+            deepEqual(val, {
+                type: 'Spy',
+                name: {
+                    first: 'Sterling',
+                    last: 'Archer'
+                }
+            });
+
+            triggered = true;
+        });
+
+        model.set('user', {
+            type: 'Spy',
+            name: {
+                first: 'Sterling',
+                last: 'Archer'
+            }
+        });
+
+        ok(triggered);
+    })();
+});
 // - @restorer


### PR DESCRIPTION
Two separate commits.

1) Trigger change events only once.
Nice feature. There are no opened pull requests like this at current moment.

2) Trigger change event for parent keys.
There are already opened pull requests like this one at current moment, but my has tests.
While this feature may not be suitable for everyone, personally I found it extremely useful.

All tests pass with source file and with distribution.
