### PR TITLE
Attach url and urlRoot directly to the model

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -122,10 +122,11 @@
         constructor: function(attributes, options) {
             var defaults;
             var attrs = attributes || {};
+            options || (options = {});
             this.cid = _.uniqueId('c');
             this.attributes = {};
-            if (options && options.collection) this.collection = options.collection;
-            if (options && options.parse) attrs = this.parse(attrs, options) || {};
+            _.extend(this, _.pick(options, ['url', 'urlRoot', 'collection']));
+            if (options.parse) attrs = this.parse(attrs, options) || {};
             if (defaults = _.result(this, 'defaults')) {
                 //<custom code>
                 // Replaced the call to _.defaults with _.deepExtend.


### PR DESCRIPTION
If provided, attach the options `url`, `urlRoot` and `collection` directly to the model.

[Backbone docs](http://backbonejs.org/docs/backbone.html#section-28)

```
new Backbone.DeepModel({}, {url: '/myurl'});
```
