### PR TITLE
Nested Backbone.Model support

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -107,7 +107,7 @@
                     options.unset ? result.unset(filed, options) : result.set(field, val, options);
                 }
                 else {
-                options.unset ? delete result[field] : result[field] = val;
+                    options.unset ? delete result[field] : result[field] = val;
                 }
             } else {
                 //Create the child object if it doesn't exist, or isn't an object
@@ -121,13 +121,14 @@
                     result = result.get(field);
                 }
                 else {
-                result = result[field];
+                    result = result[field];
+                }
             }
         }
     }
 
-    function deleteNested(obj, path) {
-      setNested(obj, path, null, { unset: true });
+    function deleteNested(obj, path, options) {
+      setNested(obj, path, null, _.extend(options || {}, { unset: true }));
     }
 
     var DeepModel = Backbone.Model.extend({
@@ -209,11 +210,11 @@
               //<custom code>: Using getNested, setNested and deleteNested
               if (!_.isEqual(getNested(current, attr), val)) changes.push(attr);
               if (!_.isEqual(getNested(prev, attr), val)) {
-                setNested(this.changed, attr, val);
+                setNested(this.changed, attr, val, options);
               } else {
                 deleteNested(this.changed, attr);
               }
-              unset ? deleteNested(current, attr) : setNested(current, attr, val);
+              unset ? deleteNested(current, attr) : setNested(current, attr, val, options);
               //</custom code>
             }
 

--- a/test/deep-model.test.js
+++ b/test/deep-model.test.js
@@ -981,6 +981,22 @@ test('set: calls set method on backbone object rather than changing attributes h
 
     ok(setCalled, 'set function called on nested object rather than modifying attributes directly');
 });
+
+test('set: silent param propagated to nested models set options with expanded syntax', function() {
+    var model = new Backbone.DeepModel();
+    var setCalledWithSilent = false;
+    var CustomModel = Backbone.DeepModel.extend({
+        set: function (key, val, options) {
+            setCalledWithSilent = options && options.silent;
+        }
+    });
+    model.set('nested', new CustomModel());
+
+    model.set('nested.property', 'value', { silent: true });
+
+    strictEqual(setCalledWithSilent, true, 'set function called on nested object with silent attribute passed');
+});
+
 test('get: calls getters on backbone object rather than accessing object directly', function() {
     var model = new Backbone.DeepModel();
     var value = 'value';


### PR DESCRIPTION
When working with nested Backbone models, I ran into a situation where DeepModel was setting changes directly on nested models after fetch.  The result was that the backbone model itself had attributes on it.  Here's the scenario:

---

Fetch -- HTTP GET returns:
{
foo: 'foo'
}

On the Model: 

{
_changing: false
_events: Object
cId: "c37",
clear: function () { [native code] }
...
foo: "foo" // Set right on the model, not on the attributes
...
url: function () { [native code] }
values: function () { [native code] }
}

---

In order to fix this, I made DeepModel check if the object being modified is a backbone model and using that object's getters and setters instead of just result[attr] = value.  

In addition, there is support (and additional tests) for:
-  Models within models within models (etc)
-  Passing options from DeepModel's set into the child model's set (e.g. silent).

If there are any other changes I should make, let me know!  Should be pretty well unit tested
