### PR TITLE
prevents the .split method to fail when the path variable is set to "false"

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -51,7 +51,7 @@
     function getNested(obj, path, return_exists) {
         var separator = DeepModel.keyPathSeparator;
 
-        var fields = path.split(separator);
+        var fields = path ? path.split(separator) : [];
         var result = obj;
         return_exists || (return_exists === false);
         for (var i = 0, n = fields.length; i < n; i++) {
@@ -91,7 +91,7 @@
 
         var separator = DeepModel.keyPathSeparator;
 
-        var fields = path.split(separator);
+        var fields = path ? path.split(separator) : [];
         var result = obj;
         for (var i = 0, n = fields.length; i < n && result !== undefined ; i++) {
             var field = fields[i];


### PR DESCRIPTION
I'm currently using Backbone + Marionette and the DeepModel is affected by the issue that I wrote as subject of this PR
