### PR TITLE
Changed from alias 'deepClone' to clone(obj, true)

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -175,7 +175,7 @@
             this._changing  = true;
 
             if (!changing) {
-              this._previousAttributes = _.clone(this.attributes, true); //<custom>: Replaced _.clone with _.deepClone
+              this._previousAttributes = _.clone(this.attributes, true);
               this.changed = {};
             }
             current = this.attributes, prev = this._previousAttributes;


### PR DESCRIPTION
I had some issues with the `_.deepClone` method - it does not seems to exist in the standard underscore library. 
Possibly `_.cloneDeep()` exists (see https://github.com/lodash/lodash/issues/140) but I suggest instead of using the alias, just using the standard method:

```
clone(obj, true)
```
