### PR TITLE
add module definition for CommonJS / browserify

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -6,6 +6,9 @@
     if (typeof define === 'function' && define.amd) {
         // AMD
         define(['underscore', 'backbone'], factory);
+    } else if (typeof exports === 'object') {
+        // CommonJS
+        module.exports = factory(require('underscore'), require('backbone'));
     } else {
         // globals
         factory(_, Backbone);


### PR DESCRIPTION
Using browserify with `require('backbone-deep-model')` fails atm because it tries to use Backbone and underscore as globals. The patch in this PR fixes this by requiring Backbone and underscore.

see http://dontkry.com/posts/code/browserify-and-the-universal-module-definition.html
