### PR TITLE
Trigger change events for nested keys when parent is changed to null or non-object

### DIFF
--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -208,6 +208,17 @@
               //</custom code>
             }
 
+            // + @restorer
+            var currentAttrs = objToPaths(current);
+            var prevAttrs = objToPaths(prev);
+
+            for (attr in prevAttrs) {
+              if (prevAttrs.hasOwnProperty(attr) && !currentAttrs.hasOwnProperty(attr)) {
+                  changes.push(attr);
+              }
+            }
+            // - @restorer
+
             // Trigger all relevant attribute changes.
             if (!silent) {
               if (changes.length) this._pending = true;

--- a/src/deep-model.js
+++ b/src/deep-model.js
@@ -213,8 +213,10 @@
             var prevAttrs = objToPaths(prev);
 
             for (attr in prevAttrs) {
-              if (prevAttrs.hasOwnProperty(attr) && !currentAttrs.hasOwnProperty(attr)) {
-                  changes.push(attr);
+              var mt = String(attr).match(/^([^.]+)\./);
+
+              if (mt && prevAttrs.hasOwnProperty(attr) && attrs.hasOwnProperty(mt[1]) && !currentAttrs.hasOwnProperty(attr)) {
+                changes.push(attr);
               }
             }
             // - @restorer

--- a/test/deep-model.test.js
+++ b/test/deep-model.test.js
@@ -940,4 +940,77 @@ test('set: Trigger model change:[attribute] event for parent keys (like wildcard
         ok(triggered);
     })();
 });
+
+test("set: Trigger change events for nested keys when parent is changed to null or non-object", function() {
+    // additional events must be triggered
+    (function() {
+        var model = new Backbone.DeepModel({
+            id: 123,
+            user: {
+                type: 'Spy',
+                name: {
+                    first: 'Sterling',
+                    last: 'Archer'
+                }
+            }
+        });
+
+        var triggeredEvents = [];
+
+        model.bind('all', function(changedAttr, model, val) {
+            triggeredEvents.push(changedAttr);
+        });
+
+        model.set('user', null);
+
+        // Check callbacks ran
+        deepEqual(triggeredEvents, [
+            'change:user',
+            'change:user.type',
+            'change:user.*',
+            'change:user.name.first',
+            'change:user.name.*',
+            'change:user.name',
+            'change:user.name.last',
+            'change'
+        ]);
+    })();
+
+    // no additional events shoud be triggered
+    (function() {
+        var model = new Backbone.DeepModel({
+            id: 123,
+            user: {
+                type: 'Spy',
+                name: {
+                    first: 'Sterling',
+                    last: 'Archer'
+                }
+            }
+        });
+
+        var triggeredEvents = [];
+
+        model.bind('all', function(changedAttr, model, val) {
+            triggeredEvents.push(changedAttr);
+        });
+
+        model.set('user', {
+            type: 'Spy',
+            name: {
+                fullname: 'Sterling Archer'
+            }
+        });
+
+        // Check callbacks ran
+        deepEqual(triggeredEvents, [
+            'change:user.name.fullname',
+            'change:user.name.*',
+            'change:user.name',
+            'change:user.*',
+            'change:user',
+            'change'
+        ]);
+    })();
+});
 // - @restorer

--- a/test/deep-model.test.js
+++ b/test/deep-model.test.js
@@ -1012,5 +1012,33 @@ test("set: Trigger change events for nested keys when parent is changed to null 
             'change'
         ]);
     })();
+
+    // infinitive loop check
+    (function() {
+        var model = new Backbone.DeepModel({
+            foo: 'foo',
+            bar: 'bar'
+        });
+
+        model.on('change:foo', function() {
+            model.set('bar', 'BAR');
+        });
+
+        var triggeredEvents = [];
+
+        model.bind('all', function(changedAttr, model, val) {
+            triggeredEvents.push(changedAttr);
+        });
+
+        model.clear();
+
+        // Check callbacks ran
+        deepEqual(triggeredEvents, [
+            'change:bar',
+            'change:foo',
+            'change:bar',
+            'change'
+        ]);
+    })();
 });
 // - @restorer


### PR DESCRIPTION
Was: { somekey: 1, anotherkey: { innerone: 1, innertwo: 2 } }
Changed to: { somekey: 1, anotherkey: null }

This change add support for triggering "change:anotherkey.innerone" and "change:anotherkey.innertwo" in this case.
